### PR TITLE
tests: authorize test as StorageCommitment caller after access control

### DIFF
--- a/tests/sharding_test.cairo
+++ b/tests/sharding_test.cairo
@@ -37,11 +37,17 @@ struct TestSetup {
     storage_commitment_dispatcher: IStorageCommitmentDispatcher,
 }
 
-/// Deploy StorageCommitment contract (from katana-tee)
+/// Deploy StorageCommitment contract (from katana-tee) and authorize test as the caller.
 fn deploy_storage_commitment() -> ContractAddress {
     let contract_class = snf::declare("StorageCommitment").unwrap().contract_class();
     let calldata: Array<felt252> = array![];
     let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+
+    // Authorize the test itself as the caller for register_verified_commitment.
+    // In production, this is the KatanaTee contract address.
+    let dispatcher = IStorageCommitmentDispatcher { contract_address };
+    dispatcher.set_authorized_caller(snf::test_address());
+
     contract_address
 }
 

--- a/tests/test_tee_commitment.cairo
+++ b/tests/test_tee_commitment.cairo
@@ -40,11 +40,17 @@ struct TeeTestSetup {
     test_contract_component_dispatcher: IContractComponentDispatcher,
 }
 
-/// Deploy StorageCommitment contract
+/// Deploy StorageCommitment contract and authorize test as the caller.
 fn deploy_storage_commitment() -> ContractAddress {
     let contract_class = snf::declare("StorageCommitment").unwrap().contract_class();
     let calldata: Array<felt252> = array![];
     let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+
+    // Authorize the test itself as the caller for register_verified_commitment.
+    // In production, this is the KatanaTee contract address.
+    let dispatcher = IStorageCommitmentDispatcher { contract_address };
+    dispatcher.set_authorized_caller(snf::test_address());
+
     contract_address
 }
 


### PR DESCRIPTION
StorageCommitment now requires authorized caller for register_verified_commitment. Tests call set_authorized_caller(snf::test_address()) after deploy.